### PR TITLE
Allow a custom firefox binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Options include:
 * `args`: additional command-line arguments to pass to Firefox. See
   [here](https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options)
   for more information.
+* `firefoxBinary`: path to a custom Firefox binary.
 * `dir`: user configuration directory to use. By default, one will be
   created and then removed when the process is killed.
 * `env`: environment variables to use. Defaults to `process.env`.

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function launchFirefox(uri, opts) {
     ].join('\n'))
   }
 
-  var ps = spawn(ffox, args, {
+  var ps = spawn(opts.firefoxBinary || ffox, args, {
     env: opts.env || process.env
   })
 


### PR DESCRIPTION
A new option can be passed in, `firefoxBinary`